### PR TITLE
package jobproxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ target/
 *.iml
 target/
 /.target
-
+dependency-reduced-pom.xml

--- a/JobProxyServer/pom.xml
+++ b/JobProxyServer/pom.xml
@@ -23,4 +23,40 @@
         </dependency>
     </dependencies>
 
+    <build>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>de.unibi.cebitec.bibiserv.jobproxy.server.JobProxyServer</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>org/datanucleus/**</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
see #5 

Implemented with maven shade plugin.
running mvn package produces a ueber oder fat jar which can be found in the target directory of jobproxyserver