### PR TITLE
rest swagger yaml and markdown added

### DIFF
--- a/doc/REST/definitions.md
+++ b/doc/REST/definitions.md
@@ -1,0 +1,44 @@
+## Definitions
+### Port
+
+Port of the host and the container system.
+
+|Name|Description|Required|Schema|Default|
+|----|----|----|----|----|
+|host|Port of the host system.|true|number||
+|container|Port of the container.|true|number||
+
+
+### TContainer
+
+Optional Docker container.
+
+|Name|Description|Required|Schema|Default|
+|----|----|----|----|----|
+|image|Docker image specification|true|string||
+|cmd|Command a Docker container should execute|false|string||
+|ports||false|TPorts||
+
+
+### TPorts
+
+Ports container could shoult map to the host system.
+
+|Name|Description|Required|Schema|Default|
+|----|----|----|----|----|
+|port||true|Port||
+
+
+### Task
+|Name|Description|Required|Schema|Default|
+|----|----|----|----|----|
+|user|Task specification representing a specific Task a Framework should run.|true|string||
+|cores|Cores a Task should use.|false|number||
+|memory|Memory used by a task.|false|number||
+|cputime|Cpu time a task is allowed to use.|false|number||
+|stdout|Path to a file for stdout a task could produce.|false|string||
+|stderr|Path to a file for stderr a task could produce.|false|string||
+|cmd|A command specified for a task|false|string||
+|container||false|TContainer||
+
+

--- a/doc/REST/overview.md
+++ b/doc/REST/overview.md
@@ -1,0 +1,16 @@
+# JobProxy
+
+## Overview
+JobProxy REST API for running task independent of the framework
+
+### Version information
+Version: 0.1.0
+
+### URI scheme
+Schemes: HTTP, HTTPS
+
+### Produces
+
+* application/json
+
+

--- a/doc/REST/paths.md
+++ b/doc/REST/paths.md
@@ -1,0 +1,29 @@
+## Paths
+### Tasks to be run
+```
+POST /jobproxy/submit
+```
+
+#### Description
+
+The submit endpoint accepts a task definition which is used to run
+on a fraemwork.
+
+
+#### Parameters
+|Type|Name|Description|Required|Schema|Default|
+|----|----|----|----|----|----|
+|BodyParameter|Task||true|Task||
+
+
+#### Responses
+|HTTP Code|Description|Schema|
+|----|----|----|
+|200|Accepted Task|No Content|
+
+
+#### Consumes
+
+* application/json
+* application/xml
+

--- a/doc/REST/swagger.yaml
+++ b/doc/REST/swagger.yaml
@@ -1,0 +1,96 @@
+# this is an example of the Uber API
+# as a demonstration of an API spec in YAML
+swagger: '2.0'
+info:
+  title: JobProxy
+  description: JobProxy REST API for running task independent of the framework
+  version: "0.1.0"
+# array of all schemes that your API supports
+schemes:
+  - http
+  - https
+produces:
+  - application/json
+paths:
+  /jobproxy/submit:
+    post:
+      summary: Tasks to be run
+      description: |
+        The submit endpoint accepts a task definition which is used to run
+        on a fraemwork.
+      parameters:
+        - name: "Task"
+          in: "body"
+          required: true
+          schema:
+            $ref: '#/definitions/Task'
+      consumes:
+        - application/json
+        - application/xml
+      responses:
+        200:
+          description: Accepted Task
+definitions:
+  Task:
+    type: object
+    required:
+     - user
+    properties:
+      user: 
+        type: string
+        description: Task specification representing a specific Task a Framework should run.
+      cores:
+        type: number
+        description: Cores a Task should use.
+      memory:
+        type: number
+        description: Memory used by a task.
+      cputime:
+        type: number
+        description: Cpu time a task is allowed to use.
+      stdout:
+        type: string
+        description: Path to a file for stdout a task could produce.
+      stderr:
+        type: string
+        description: Path to a file for stderr a task could produce.
+      cmd:
+        type: string
+        description: A command specified for a task
+      container:
+        $ref: '#/definitions/TContainer'
+  TContainer:
+    description: Optional Docker container.
+    type: object
+    required:
+     - image
+    properties:
+      image:
+        type: string
+        description: Docker image specification
+      cmd:
+        type: string
+        description: Command a Docker container should execute
+      ports:
+        $ref: '#/definitions/TPorts'
+  TPorts:
+    description: Ports container could shoult map to the host system.
+    type: object
+    required:
+      - port
+    properties:
+      port:
+        $ref: '#/definitions/Port'
+  Port:
+    description: Port of the host and the container system.
+    type: object
+    required:
+      - host
+      - container
+    properties:
+      host:
+        type: number
+        description: Port of the host system.
+      container:
+        type: number
+        description: Port of the container. 


### PR DESCRIPTION
I added a swagger yaml in doc/REST folder. 
It allows us to generate Markdown/html/Asciidoctor and other formats.
This also allow us to produce client code (java and python) with swagger-codegen (http://swagger.io/swagger-codegen/)
At the moment I used this https://github.com/Swagger2Markup/swagger2markup-cli to produce the markup overview/path and model documents.

In the next step we could try to generate  asciidoctor and maybe use the maven swagger plugin.