### PR TITLE
add services resource transformer for shade plugin

### DIFF
--- a/JobProxyServerCLI/pom.xml
+++ b/JobProxyServerCLI/pom.xml
@@ -39,6 +39,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>de.unibi.cebitec.bibiserv.jobproxy.server.cli.CLI</mainClass>
                                 </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>


### PR DESCRIPTION
META-INF/services/ directory is used for mapping interfaces to their implementation classes.
To merge multiple implementations of the same interface into one service entry, the ServicesResourceTransformer can be used. 

It maybe even fixes #66 